### PR TITLE
Add async event support via `input()` method on `Screen`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,12 @@ bitflags = "1"
 crossterm = "0.18"
 textwrap = "0.12"
 unicode-width = "0.1"
+futures-core = { optional = true, version = "0.3" }
+
+[dev-dependencies]
+pasts = "0.6"
+futures = "0.3"
+
+[features]
+default = ["async"]
+async = ["futures-core", "crossterm/event-stream"]

--- a/examples/grid_futures.rs
+++ b/examples/grid_futures.rs
@@ -33,6 +33,6 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn main() {
-    pasts::exec!(async { async_main().await.expect("async_main errored") });
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    futures::executor::block_on(async_main())
 }


### PR DESCRIPTION
Includes examples using the pasts crate and the futures crate.